### PR TITLE
fix stale v2.0 hook URL in browser_auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.6.25] - 2026-03-28
+
+### Fixed
+- `Hooks::Auth` — migrated from v2.0 `Routes::Hooks` pattern to v3.0 `LexDispatch` pattern: replaced instance `route`/`runner_class` overrides with a class-level `self.runner_class`; hook now registers as `POST /api/extensions/microsoft_teams/hooks/auth/handle` (was `/api/hooks/lex/microsoft_teams/auth/callback`)
+- `Runners::Auth` — added `handle` alias for `auth_callback` so LexDispatch's default `:handle` routing resolves correctly
+- `Helpers::BrowserAuth` — updated all three references to the hook redirect URI and probe path from the stale v2.0 path to `/api/extensions/microsoft_teams/hooks/auth/handle`
+
 ## [0.6.24] - 2026-03-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Legion::Extensions::MicrosoftTeams
 │   ├── TraceRetriever    # Retrieves memory traces from the shared store for bot context (2000-token budget, strength-ranked dedup)
 │   └── TransformDefinitions # lex-transformer definitions for conversation extraction and person summary
 ├── Hooks/
-│   └── Auth              # OAuth callback hook (mount '/callback') → /api/hooks/lex/microsoft_teams/auth/callback
+│   └── Auth              # OAuth callback hook (mount '/callback') → /api/extensions/microsoft_teams/hooks/auth/handle
 ├── CLI/
 │   └── Auth              # CLI module for `legion lex exec teams auth login/status`
 └── Client                # Standalone client (includes all runners)
@@ -74,10 +74,10 @@ Legion::Extensions::MicrosoftTeams
 
 Opt-in browser-based OAuth for delegated Microsoft Graph permissions. Two flows:
 
-- **Authorization Code + PKCE** (primary): Opens browser for Entra ID login. When the Legion API is running, uses the hook URL (`/api/hooks/lex/microsoft_teams/auth/callback`) with `Legion::Events` for callback notification; otherwise falls back to an ephemeral local port via `CallbackServer`
+- **Authorization Code + PKCE** (primary): Opens browser for Entra ID login. When the Legion API is running, uses the hook URL (`/api/extensions/microsoft_teams/hooks/auth/handle`) with `Legion::Events` for callback notification; otherwise falls back to an ephemeral local port via `CallbackServer`
 - **Device Code** (fallback): Auto-selected in headless/SSH environments (no `DISPLAY`/`WAYLAND_DISPLAY`)
 
-Tokens stored in Vault at a per-user path (`{USER}/microsoft_teams/delegated_token`, where `{USER}` is the system username) with configurable pre-expiry silent refresh. CLI command: `legion auth teams`. Hook route: `GET|POST /api/hooks/lex/microsoft_teams/auth/callback` for daemon re-auth (routed through Ingress for RBAC/audit).
+Tokens stored in Vault at a per-user path (`{USER}/microsoft_teams/delegated_token`, where `{USER}` is the system username) with configurable pre-expiry silent refresh. CLI command: `legion auth teams`. Hook route: `POST /api/extensions/microsoft_teams/hooks/auth/handle` for daemon re-auth (routed through LexDispatch for RBAC/audit).
 
 Key files: `Helpers::BrowserAuth` (orchestrator), `Helpers::CallbackServer` (ephemeral TCP), `Runners::Auth` (authorize_url, exchange_code, refresh_delegated_token, auth_callback), `Helpers::TokenCache` (delegated slot), `Hooks::Auth` (hook class with mount path).
 

--- a/lib/legion/extensions/microsoft_teams/helpers/browser_auth.rb
+++ b/lib/legion/extensions/microsoft_teams/helpers/browser_auth.rb
@@ -72,7 +72,7 @@ module Legion
                    else
                      4567
                    end
-            "http://127.0.0.1:#{port}/api/hooks/lex/microsoft_teams/auth/callback"
+            "http://127.0.0.1:#{port}/api/extensions/microsoft_teams/hooks/auth/handle"
           end
 
           def generate_pkce
@@ -121,9 +121,9 @@ module Legion
           def hook_route_registered?
             return false unless defined?(Legion::API)
 
-            log.debug("Probing hook route at http://127.0.0.1:#{api_port}/api/hooks/lex/microsoft_teams/auth/callback")
+            log.debug("Probing hook route at http://127.0.0.1:#{api_port}/api/extensions/microsoft_teams/hooks/auth/handle")
             conn = Faraday.new(url: "http://127.0.0.1:#{api_port}")
-            resp = conn.head('/api/hooks/lex/microsoft_teams/auth/callback')
+            resp = conn.head('/api/extensions/microsoft_teams/hooks/auth/handle')
             registered = resp.status != 404
             log.debug("Hook route probe returned #{resp.status} (registered=#{registered})")
             registered

--- a/lib/legion/extensions/microsoft_teams/hooks/auth.rb
+++ b/lib/legion/extensions/microsoft_teams/hooks/auth.rb
@@ -7,11 +7,7 @@ module Legion
         class Auth < Legion::Extensions::Hooks::Base
           mount '/callback'
 
-          def route(_headers, _payload)
-            :auth_callback
-          end
-
-          def runner_class
+          def self.runner_class
             'Legion::Extensions::MicrosoftTeams::Runners::Auth'
           end
         end

--- a/lib/legion/extensions/microsoft_teams/runners/auth.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/auth.rb
@@ -124,6 +124,7 @@ module Legion
                           body: callback_success_html }
             }
           end
+          alias handle auth_callback
 
           private
 

--- a/lib/legion/extensions/microsoft_teams/version.rb
+++ b/lib/legion/extensions/microsoft_teams/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module MicrosoftTeams
-      VERSION = '0.6.24'
+      VERSION = '0.6.25'
     end
   end
 end

--- a/spec/legion/extensions/microsoft_teams/helpers/browser_auth_spec.rb
+++ b/spec/legion/extensions/microsoft_teams/helpers/browser_auth_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Legion::Extensions::MicrosoftTeams::Helpers::BrowserAuth do
   describe '#hook_redirect_uri' do
     it 'builds the hook URL with default port' do
       expect(browser_auth.hook_redirect_uri).to eq(
-        'http://127.0.0.1:4567/api/hooks/lex/microsoft_teams/auth/callback'
+        'http://127.0.0.1:4567/api/extensions/microsoft_teams/hooks/auth/handle'
       )
     end
   end

--- a/spec/legion/extensions/microsoft_teams/hooks/auth_spec.rb
+++ b/spec/legion/extensions/microsoft_teams/hooks/auth_spec.rb
@@ -44,16 +44,15 @@ RSpec.describe Legion::Extensions::MicrosoftTeams::Hooks::Auth do
   end
 
   describe '#route' do
-    it 'always routes to auth_callback' do
+    it 'returns :handle (base default, no DSL configured)' do
       hook = described_class.new
-      expect(hook.route({}, {})).to eq(:auth_callback)
+      expect(hook.route({}, {})).to eq(:handle)
     end
   end
 
-  describe '#runner_class' do
+  describe '.runner_class' do
     it 'returns the Auth runner class name' do
-      hook = described_class.new
-      expect(hook.runner_class).to eq('Legion::Extensions::MicrosoftTeams::Runners::Auth')
+      expect(described_class.runner_class).to eq('Legion::Extensions::MicrosoftTeams::Runners::Auth')
     end
   end
 


### PR DESCRIPTION
## Summary
- Update hook URL from `/api/hooks/lex/` to `/api/extensions/` path in `browser_auth.rb` to match v3.0 routing (0.6.25)

## Test plan
- [x] `bundle exec rspec` passes
- [x] `bundle exec rubocop` passes