### PR TITLE
feat: add Runners::Loop for Loop component support via fluidEmbedCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [0.7.0] - unreleased
+
+### Added
+- New `Runners::Loop` module with four functions for Microsoft Loop component support via `fluidEmbedCard`:
+  - `create_loop_file` — Creates a new `.loop` file in a user's OneDrive via the Graph API; returns drive item metadata including `webUrl`
+  - `loop_attachment` — Builds the `fluidEmbedCard` + placeholder attachment pair required to embed a Loop component in a Teams message
+  - `post_loop_to_chat` — Posts a Loop component inline into a Teams chat thread
+  - `post_loop_to_channel` — Posts a Loop component inline into a Teams channel thread
+- Requires `Files.ReadWrite` and `Sites.ReadWrite.All` Graph API permissions for `create_loop_file`; `Chat.ReadWrite` and `ChannelMessage.Send` are already required by existing runners
+- **Note:** Programmatic write access to Loop page *content* (Fluid Framework) is not yet available via Microsoft Graph; Loop files must be opened in Teams to initialize the collaborative session
+
 ## [0.6.36] - 2026-04-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ gem install lex-microsoft_teams
 - `action_submit` — Create a Submit action
 - `message_attachment` — Wrap a card as a message attachment
 
+### Loop Components
+- `create_loop_file` — Create a new `.loop` file in a user's OneDrive; returns drive item metadata including `webUrl`
+- `loop_attachment` — Build a `fluidEmbedCard` attachment array for embedding an existing Loop component URL in a Teams message
+- `post_loop_to_chat` — Post a Loop component inline into a Teams chat thread
+- `post_loop_to_channel` — Post a Loop component inline into a Teams channel thread
+
+> **Note:** Creating a `.loop` file provisions the OneDrive item; the Fluid Framework collaborative session is initialized by Teams on first open. Programmatic write access to Loop page *content* is not yet available via Microsoft Graph.
+
 ### Bot Framework
 - `send_activity` — Send an activity to a conversation
 - `reply_to_activity` — Reply to an existing activity

--- a/lib/legion/extensions/microsoft_teams/client.rb
+++ b/lib/legion/extensions/microsoft_teams/client.rb
@@ -15,6 +15,7 @@ require 'legion/extensions/microsoft_teams/runners/meetings'
 require 'legion/extensions/microsoft_teams/runners/transcripts'
 require 'legion/extensions/microsoft_teams/runners/people'
 require 'legion/extensions/microsoft_teams/runners/ownership'
+require 'legion/extensions/microsoft_teams/runners/loop'
 
 module Legion
   module Extensions
@@ -37,6 +38,7 @@ module Legion
         include Runners::CacheIngest
         include Runners::People
         include Runners::Ownership
+        include Runners::Loop
 
         attr_reader :opts
 

--- a/lib/legion/extensions/microsoft_teams/runners/loop.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/loop.rb
@@ -9,6 +9,7 @@ module Legion
       module Runners
         module Loop
           include Legion::Extensions::MicrosoftTeams::Helpers::Client
+          include Legion::JSON::Helper
 
           # Creates a new .loop file in the user's OneDrive via the Graph API.
           # The Fluid Framework collaborative session is initialized by Teams on first open.
@@ -47,7 +48,7 @@ module Legion
                   id:          attachment_id,
                   contentType: 'application/vnd.microsoft.card.fluidEmbedCard',
                   contentUrl:  nil,
-                  content:     Legion::JSON.generate({ componentUrl: component_url, sourceType: source_type }),
+                  content:     json_generate({ componentUrl: component_url, sourceType: source_type }),
                   teamsAppId:  'FluidEmbedCard'
                 },
                 {

--- a/lib/legion/extensions/microsoft_teams/runners/loop.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/loop.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'securerandom'
+require 'legion/extensions/microsoft_teams/helpers/client'
+
+module Legion
+  module Extensions
+    module MicrosoftTeams
+      module Runners
+        module Loop
+          include Legion::Extensions::MicrosoftTeams::Helpers::Client
+
+          # Creates a new .loop file in the user's OneDrive via the Graph API.
+          # The Fluid Framework collaborative session is initialized by Teams on first open.
+          # Returns the drive item metadata including +webUrl+, which can be passed to
+          # +post_loop_to_chat+ or +post_loop_to_channel+.
+          #
+          # @param filename     [String] Name of the file (e.g. "incident-status" or "incident-status.loop")
+          # @param folder_path  [String] OneDrive folder path relative to root (default: root)
+          # @param user_id      [String] Graph user ID or 'me' (default: 'me')
+          def create_loop_file(filename:, folder_path: nil, user_id: 'me', **)
+            filename = "#{filename}.loop" unless filename.end_with?('.loop')
+
+            path = if folder_path.nil? || folder_path.empty?
+                     "users/#{user_id}/drive/root:/#{filename}:/content"
+                   else
+                     "users/#{user_id}/drive/root:/#{folder_path}/#{filename}:/content"
+                   end
+
+            response = graph_connection(**).put(path, '', 'Content-Type' => 'application/octet-stream')
+            { result: response.body }
+          end
+
+          # Builds the fluidEmbedCard attachment array required to embed a Loop component
+          # in a Teams message. Pass the resulting array as +attachments:+ to
+          # +send_chat_message+ / +send_channel_message+, or use the convenience methods
+          # +post_loop_to_chat+ and +post_loop_to_channel+.
+          #
+          # @param component_url [String] SharePoint/OneDrive URL of the .loop file
+          #                               (the +webUrl+ from +create_loop_file+)
+          # @param source_type   [String] 'Compose' (default) or 'Loop'
+          def loop_attachment(component_url:, source_type: 'Compose', **)
+            attachment_id = SecureRandom.hex(16)
+            {
+              result: [
+                {
+                  id:          attachment_id,
+                  contentType: 'application/vnd.microsoft.card.fluidEmbedCard',
+                  contentUrl:  nil,
+                  content:     JSON.generate({ componentUrl: component_url, sourceType: source_type }),
+                  teamsAppId:  'FluidEmbedCard'
+                },
+                {
+                  id:          'placeholderCard',
+                  contentType: 'application/vnd.microsoft.card.codesnippet',
+                  content:     '{}',
+                  teamsAppId:  'FLUID_PLACEHOLDER_CARD'
+                }
+              ]
+            }
+          end
+
+          # Posts a message into a Teams chat thread with a Loop component embedded inline.
+          #
+          # @param chat_id       [String] Teams chat thread ID (e.g. 19:...@thread.v2)
+          # @param component_url [String] SharePoint/OneDrive URL of the .loop file
+          # @param body_text     [String] Optional plain-text preamble shown above the component
+          def post_loop_to_chat(chat_id:, component_url:, body_text: '', **)
+            attachments = loop_attachment(component_url: component_url, **)[:result]
+            content     = body_text.empty? ? '<p></p>' : "<p>#{body_text}</p>"
+            payload     = { body: { contentType: 'html', content: content }, attachments: attachments }
+            response    = graph_connection(**).post("chats/#{chat_id}/messages", payload)
+            { result: response.body }
+          end
+
+          # Posts a message into a Teams channel thread with a Loop component embedded inline.
+          #
+          # @param team_id       [String] Teams team ID
+          # @param channel_id    [String] Teams channel ID
+          # @param component_url [String] SharePoint/OneDrive URL of the .loop file
+          # @param body_text     [String] Optional plain-text preamble shown above the component
+          # @param subject       [String] Optional thread subject line
+          def post_loop_to_channel(team_id:, channel_id:, component_url:, body_text: '', subject: nil, **)
+            attachments = loop_attachment(component_url: component_url, **)[:result]
+            content     = body_text.empty? ? '<p></p>' : "<p>#{body_text}</p>"
+            payload     = { body: { contentType: 'html', content: content }, attachments: attachments }
+            payload[:subject] = subject if subject
+            response = graph_connection(**).post("teams/#{team_id}/channels/#{channel_id}/messages", payload)
+            { result: response.body }
+          end
+
+          include Legion::Extensions::Helpers::Lex if Legion::Extensions.const_defined?(:Helpers, false) &&
+                                                      Legion::Extensions::Helpers.const_defined?(:Lex, false)
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/extensions/microsoft_teams/runners/loop.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/loop.rb
@@ -48,7 +48,7 @@ module Legion
                   id:          attachment_id,
                   contentType: 'application/vnd.microsoft.card.fluidEmbedCard',
                   contentUrl:  nil,
-                  content:     JSON.generate({ componentUrl: component_url, sourceType: source_type }),
+                  content:     ::JSON.generate({ componentUrl: component_url, sourceType: source_type }),
                   teamsAppId:  'FluidEmbedCard'
                 },
                 {

--- a/lib/legion/extensions/microsoft_teams/runners/loop.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/loop.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
 require 'securerandom'
 require 'legion/extensions/microsoft_teams/helpers/client'
 
@@ -48,7 +47,7 @@ module Legion
                   id:          attachment_id,
                   contentType: 'application/vnd.microsoft.card.fluidEmbedCard',
                   contentUrl:  nil,
-                  content:     ::JSON.generate({ componentUrl: component_url, sourceType: source_type }),
+                  content:     Legion::JSON.generate({ componentUrl: component_url, sourceType: source_type }),
                   teamsAppId:  'FluidEmbedCard'
                 },
                 {

--- a/lib/legion/extensions/microsoft_teams/version.rb
+++ b/lib/legion/extensions/microsoft_teams/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module MicrosoftTeams
-      VERSION = '0.6.36'
+      VERSION = '0.6.37'
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds `Runners::Loop` module to support Microsoft Teams Loop components via the Graph API.

### New methods

| Method | Description |
|---|---|
| `create_loop_file` | Creates a `.loop` file in the user's OneDrive via Graph API |
| `loop_attachment` | Builds the `fluidEmbedCard` attachment payload for embedding a Loop component in a message |
| `post_loop_to_chat` | Posts a message with an embedded Loop component to a chat thread |
| `post_loop_to_channel` | Posts a message with an embedded Loop component to a channel thread |
