### PR TITLE
fix definition DSL NoMethodError at extension load

### DIFF
--- a/lib/legion/extensions/microsoft_teams/runners/activities.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/activities.rb
@@ -7,6 +7,7 @@ module Legion
     module MicrosoftTeams
       module Runners
         module Activities
+          extend Legion::Extensions::Definitions
           include Legion::Extensions::MicrosoftTeams::Helpers::Client
 
           def self.trigger_words

--- a/lib/legion/extensions/microsoft_teams/runners/ai_insights.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/ai_insights.rb
@@ -7,6 +7,7 @@ module Legion
     module MicrosoftTeams
       module Runners
         module AiInsights
+          extend Legion::Extensions::Definitions
           include Legion::Extensions::MicrosoftTeams::Helpers::Client
 
           def self.trigger_words

--- a/lib/legion/extensions/microsoft_teams/runners/api_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/api_ingest.rb
@@ -11,6 +11,7 @@ module Legion
     module MicrosoftTeams
       module Runners
         module ApiIngest
+          extend Legion::Extensions::Definitions
           include Helpers::Client
           include Helpers::PermissionGuard
           include Helpers::HighWaterMark

--- a/lib/legion/extensions/microsoft_teams/runners/app_installations.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/app_installations.rb
@@ -7,6 +7,7 @@ module Legion
     module MicrosoftTeams
       module Runners
         module AppInstallations
+          extend Legion::Extensions::Definitions
           include Legion::Extensions::MicrosoftTeams::Helpers::Client
 
           def self.trigger_words

--- a/lib/legion/extensions/microsoft_teams/runners/auth.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/auth.rb
@@ -7,6 +7,7 @@ module Legion
     module MicrosoftTeams
       module Runners
         module Auth
+          extend Legion::Extensions::Definitions
           include Legion::Extensions::MicrosoftTeams::Helpers::Client
 
           definition :acquire_token, mcp_exposed: false

--- a/lib/legion/extensions/microsoft_teams/runners/cache_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/cache_ingest.rb
@@ -7,6 +7,8 @@ module Legion
     module MicrosoftTeams
       module Runners
         module CacheIngest
+          extend Legion::Extensions::Definitions
+
           definition :ingest_cache, mcp_exposed: false
 
           # Ingest Teams messages from local cache into lex-memory traces.

--- a/lib/legion/extensions/microsoft_teams/runners/channels.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/channels.rb
@@ -7,6 +7,7 @@ module Legion
     module MicrosoftTeams
       module Runners
         module Channels
+          extend Legion::Extensions::Definitions
           include Legion::Extensions::MicrosoftTeams::Helpers::Client
 
           def self.trigger_words

--- a/lib/legion/extensions/microsoft_teams/runners/chats.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/chats.rb
@@ -7,6 +7,7 @@ module Legion
     module MicrosoftTeams
       module Runners
         module Chats
+          extend Legion::Extensions::Definitions
           include Legion::Extensions::MicrosoftTeams::Helpers::Client
 
           def self.trigger_words

--- a/lib/legion/extensions/microsoft_teams/runners/loop.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/loop.rb
@@ -8,6 +8,7 @@ module Legion
     module MicrosoftTeams
       module Runners
         module Loop
+          extend Legion::Extensions::Definitions
           include Legion::Extensions::MicrosoftTeams::Helpers::Client
           include Legion::JSON::Helper
 

--- a/lib/legion/extensions/microsoft_teams/runners/messages.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/messages.rb
@@ -7,6 +7,7 @@ module Legion
     module MicrosoftTeams
       module Runners
         module Messages
+          extend Legion::Extensions::Definitions
           include Legion::Extensions::MicrosoftTeams::Helpers::Client
 
           def self.trigger_words

--- a/lib/legion/extensions/microsoft_teams/runners/people.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/people.rb
@@ -7,6 +7,7 @@ module Legion
     module MicrosoftTeams
       module Runners
         module People
+          extend Legion::Extensions::Definitions
           include Legion::Extensions::MicrosoftTeams::Helpers::Client
 
           def self.trigger_words

--- a/lib/legion/extensions/microsoft_teams/runners/profile_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/profile_ingest.rb
@@ -11,6 +11,7 @@ module Legion
     module MicrosoftTeams
       module Runners
         module ProfileIngest
+          extend Legion::Extensions::Definitions
           include Helpers::Client
           include Helpers::PermissionGuard
           include Helpers::HighWaterMark

--- a/lib/legion/extensions/microsoft_teams/version.rb
+++ b/lib/legion/extensions/microsoft_teams/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module MicrosoftTeams
-      VERSION = '0.6.46'
+      VERSION = '0.6.47'
     end
   end
 end


### PR DESCRIPTION
## Summary

- All 12 runner modules call `definition` at module body level, but `Legion::Extensions::Definitions` hasn't been extended onto them yet at that point (it happens later in the builder). This causes `NoMethodError: undefined method 'definition'` when the extension loads.
- Added `extend Legion::Extensions::Definitions` as the first line inside each affected runner module, before any `include` or `definition` calls.
- Bumped version to 0.6.47.

Closes #14

## Affected files

- `runners/auth.rb`
- `runners/activities.rb`
- `runners/ai_insights.rb`
- `runners/api_ingest.rb`
- `runners/app_installations.rb`
- `runners/cache_ingest.rb`
- `runners/channels.rb`
- `runners/chats.rb`
- `runners/loop.rb`
- `runners/messages.rb`
- `runners/people.rb`
- `runners/profile_ingest.rb`

## Test plan

- [x] `bundle exec rspec` — full suite passes (exit 0)
- [x] `bundle exec rubocop -A` — no offenses detected