### PR TITLE
A1-A4: Teams ingest fixes (throttle, HWM, members, trace spam)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,10 @@ Legion/Extension/EveryActorRequiresTime:
 # RunnerReturnHash fires on private helper methods inside runner modules (false positives)
 Legion/Extension/RunnerReturnHash:
   Enabled: false
+
+# This extension uses trace types (episodic, semantic, procedural) not LLM taxonomy types
+Legion/Llm/TaxonomyEnum:
+  Enabled: false
   
 Metrics/CyclomaticComplexity:
   Max: 25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.6.53] - 2026-07-15
+### Fixed
+- Fix throttle propagation, invalid OData filter, member index priority, stop trace spam from API fetches
+
 ## [0.6.52] - 2026-05-29
 ### Fixed
 - **Actors now defer their next scheduled run on a Graph throttle** instead of re-firing on their fixed timer interval — resolves the 0.6.51 "Known follow-up". New `Helpers::ThrottleAware` mixin records a "suppress until" instant of `now + retry_after` when a Graph call raises `Errors::Throttled`; subsequent ticks short-circuit until that window elapses. Wired into `PresencePoller`, `MeetingIngest`, and `ApiIngest`. Falls back to a bounded 60s deferral when the server gave no usable `Retry-After`, and clamps any single deferral to 600s. Previously a poller on a 30–300s interval would walk straight back into the still-open shared circuit every interval, emitting a `[throttle_circuit] hard circuit` ERROR (and a duplicate `Errors::Throttled` WARN/ERROR) each tick while ingesting nothing.

--- a/lib/legion/extensions/microsoft_teams.rb
+++ b/lib/legion/extensions/microsoft_teams.rb
@@ -107,7 +107,8 @@ module Legion
             interval: 60
           },
           cache:                {
-            graph_ttl: 300
+            graph_ttl:   300,
+            members_ttl: 86_400
           },
           client:               {
             throttle_circuit: {

--- a/lib/legion/extensions/microsoft_teams/absorbers/channel.rb
+++ b/lib/legion/extensions/microsoft_teams/absorbers/channel.rb
@@ -57,7 +57,7 @@ module Legion
           def graph_token
             Legion::Extensions::Identity::Entra::Helpers::TokenManager.load_token(:delegated)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'Channel#graph_token')
+            handle_exception(e, level: :warn, operation: 'Channel#graph_token')
             nil
           end
 
@@ -85,7 +85,7 @@ module Legion
 
             { team_id: team_id, channel_id: channel_id, message_id: message_id }
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'Channel#extract_ids', url: url)
+            handle_exception(e, level: :warn, operation: 'Channel#extract_ids', url: url)
             nil
           end
 
@@ -202,7 +202,7 @@ module Legion
               "  ↳ [#{timestamp}] #{sender}: #{text}"
             end
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'Channel#fetch_reply_lines',
+            handle_exception(e, level: :warn, operation: 'Channel#fetch_reply_lines',
                              team_id: team_id, channel_id: channel_id, message_id: message_id)
             []
           end

--- a/lib/legion/extensions/microsoft_teams/absorbers/chat.rb
+++ b/lib/legion/extensions/microsoft_teams/absorbers/chat.rb
@@ -46,7 +46,7 @@ module Legion
           def graph_token
             Legion::Extensions::Identity::Entra::Helpers::TokenManager.load_token(:delegated)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'Chat#graph_token')
+            handle_exception(e, level: :warn, operation: 'Chat#graph_token')
             nil
           end
 
@@ -60,7 +60,7 @@ module Legion
 
             URI.decode_uri_component(match[1])
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'Chat#extract_chat_id', url: url)
+            handle_exception(e, level: :warn, operation: 'Chat#extract_chat_id', url: url)
             nil
           end
 
@@ -150,7 +150,7 @@ module Legion
               "  ↳ [#{timestamp}] #{sender}: #{text}"
             end
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'Chat#fetch_reply_lines',
+            handle_exception(e, level: :warn, operation: 'Chat#fetch_reply_lines',
                              chat_id: chat_id, message_id: message_id)
             []
           end

--- a/lib/legion/extensions/microsoft_teams/absorbers/meeting.rb
+++ b/lib/legion/extensions/microsoft_teams/absorbers/meeting.rb
@@ -51,7 +51,7 @@ module Legion
           def graph_token
             Legion::Extensions::Identity::Entra::Helpers::TokenManager.load_token(:delegated)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'Meeting#graph_token')
+            handle_exception(e, level: :warn, operation: 'Meeting#graph_token')
             nil
           end
 
@@ -75,7 +75,7 @@ module Legion
             match = uri.path.match(%r{/l/chat/(19:meeting_[^/]+)})
             match&.[](1)
           rescue URI::InvalidURIError => e
-            handle_exception(e, level: :debug, operation: 'Meeting#extract_meeting_thread_id', url: url)
+            handle_exception(e, level: :warn, operation: 'Meeting#extract_meeting_thread_id', url: url)
             nil
           end
 

--- a/lib/legion/extensions/microsoft_teams/actors/absorb_channel.rb
+++ b/lib/legion/extensions/microsoft_teams/actors/absorb_channel.rb
@@ -14,7 +14,7 @@ module Legion
             defined?(Legion::Extensions::Absorbers::Base) &&
               defined?(Legion::Extensions::MicrosoftTeams::Absorbers::Channel)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'AbsorbChannel#enabled?')
+            handle_exception(e, level: :warn, operation: 'AbsorbChannel#enabled?')
             false
           end
 
@@ -53,7 +53,7 @@ module Legion
 
             data.transform_keys(&:to_sym)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'AbsorbChannel#parse_payload')
+            handle_exception(e, level: :warn, operation: 'AbsorbChannel#parse_payload')
             {}
           end
         end

--- a/lib/legion/extensions/microsoft_teams/actors/absorb_chat.rb
+++ b/lib/legion/extensions/microsoft_teams/actors/absorb_chat.rb
@@ -14,7 +14,7 @@ module Legion
             defined?(Legion::Extensions::Absorbers::Base) &&
               defined?(Legion::Extensions::MicrosoftTeams::Absorbers::Chat)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'AbsorbChat#enabled?')
+            handle_exception(e, level: :warn, operation: 'AbsorbChat#enabled?')
             false
           end
 
@@ -53,7 +53,7 @@ module Legion
 
             data.transform_keys(&:to_sym)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'AbsorbChat#parse_payload')
+            handle_exception(e, level: :warn, operation: 'AbsorbChat#parse_payload')
             {}
           end
         end

--- a/lib/legion/extensions/microsoft_teams/actors/absorb_meeting.rb
+++ b/lib/legion/extensions/microsoft_teams/actors/absorb_meeting.rb
@@ -14,7 +14,7 @@ module Legion
             defined?(Legion::Extensions::Absorbers::Base) &&
               defined?(Legion::Extensions::MicrosoftTeams::Absorbers::Meeting)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'AbsorbMeeting#enabled?')
+            handle_exception(e, level: :warn, operation: 'AbsorbMeeting#enabled?')
             false
           end
 
@@ -53,7 +53,7 @@ module Legion
 
             data.transform_keys(&:to_sym)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'AbsorbMeeting#parse_payload')
+            handle_exception(e, level: :warn, operation: 'AbsorbMeeting#parse_payload')
             {}
           end
         end

--- a/lib/legion/extensions/microsoft_teams/actors/api_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/actors/api_ingest.rb
@@ -24,7 +24,7 @@ module Legion
             base_delay = auth_validator.respond_to?(:delay) ? auth_validator.delay.to_f : 9.0
             [base_delay + 5.0, 14].max
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'ApiIngest#delay')
+            handle_exception(e, level: :warn, operation: 'ApiIngest#delay')
             14
           end
 
@@ -93,7 +93,7 @@ module Legion
 
             Legion::Extensions::Coldstart::Helpers::Bootstrap.new.imprint_active?
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'ApiIngest#imprint_active?')
+            handle_exception(e, level: :warn, operation: 'ApiIngest#imprint_active?')
             false
           end
         end

--- a/lib/legion/extensions/microsoft_teams/actors/cache_bulk_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/actors/cache_bulk_ingest.rb
@@ -41,7 +41,7 @@ module Legion
 
             Legion::Extensions::Coldstart::Helpers::Bootstrap.new.imprint_active?
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'CacheBulkIngest#imprint_active?')
+            handle_exception(e, level: :warn, operation: 'CacheBulkIngest#imprint_active?')
             false
           end
         end

--- a/lib/legion/extensions/microsoft_teams/actors/channel_poller.rb
+++ b/lib/legion/extensions/microsoft_teams/actors/channel_poller.rb
@@ -34,7 +34,7 @@ module Legion
           def enabled?
             settings.dig(:channel_poller, :enabled)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'ChannelPoller#enabled?')
+            handle_exception(e, level: :warn, operation: 'ChannelPoller#enabled?')
             false
           end
 

--- a/lib/legion/extensions/microsoft_teams/actors/direct_chat_poller.rb
+++ b/lib/legion/extensions/microsoft_teams/actors/direct_chat_poller.rb
@@ -29,7 +29,7 @@ module Legion
               defined?(Legion::Extensions::MicrosoftTeams::Runners::Bot) &&
               Legion.const_defined?(:Transport, false)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'DirectChatPoller#enabled?')
+            handle_exception(e, level: :warn, operation: 'DirectChatPoller#enabled?')
             false
           end
 

--- a/lib/legion/extensions/microsoft_teams/actors/incremental_sync.rb
+++ b/lib/legion/extensions/microsoft_teams/actors/incremental_sync.rb
@@ -22,7 +22,7 @@ module Legion
               defined?(Legion::Extensions::Agentic::Memory::Trace::Runners::Traces) &&
               token_available?
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'IncrementalSync#enabled?')
+            handle_exception(e, level: :warn, operation: 'IncrementalSync#enabled?')
             false
           end
 

--- a/lib/legion/extensions/microsoft_teams/actors/meeting_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/actors/meeting_ingest.rb
@@ -28,7 +28,7 @@ module Legion
             settings.dig(:meeting_ingest, :enabled) &&
               Legion::Extensions::Identity::Entra::Helpers::TokenManager.respond_to?(:load_token)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'MeetingIngest#enabled?')
+            handle_exception(e, level: :warn, operation: 'MeetingIngest#enabled?')
             false
           end
 

--- a/lib/legion/extensions/microsoft_teams/actors/observed_chat_poller.rb
+++ b/lib/legion/extensions/microsoft_teams/actors/observed_chat_poller.rb
@@ -28,7 +28,7 @@ module Legion
               defined?(Legion::Extensions::MicrosoftTeams::Runners::Bot) &&
               Legion.const_defined?(:Transport, false)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'ObservedChatPoller#enabled?')
+            handle_exception(e, level: :warn, operation: 'ObservedChatPoller#enabled?')
             false
           end
 

--- a/lib/legion/extensions/microsoft_teams/actors/presence_poller.rb
+++ b/lib/legion/extensions/microsoft_teams/actors/presence_poller.rb
@@ -23,7 +23,7 @@ module Legion
             settings.dig(:presence_poller, :enabled) &&
               Legion::Extensions::Identity::Entra::Helpers::TokenManager.respond_to?(:load_token)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'PresencePoller#enabled?')
+            handle_exception(e, level: :warn, operation: 'PresencePoller#enabled?')
             false
           end
 

--- a/lib/legion/extensions/microsoft_teams/actors/profile_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/actors/profile_ingest.rb
@@ -16,7 +16,7 @@ module Legion
             base_delay = auth_validator.respond_to?(:delay) ? auth_validator.delay.to_f : 9.0
             base_delay + 5.0
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'ProfileIngest#delay')
+            handle_exception(e, level: :warn, operation: 'ProfileIngest#delay')
             14.0
           end
 
@@ -25,7 +25,7 @@ module Legion
               defined?(Legion::Extensions::Agentic::Memory::Trace::Runners::Traces) &&
               token_available?
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'ProfileIngest#enabled?')
+            handle_exception(e, level: :warn, operation: 'ProfileIngest#enabled?')
             false
           end
 

--- a/lib/legion/extensions/microsoft_teams/faraday/retry_after.rb
+++ b/lib/legion/extensions/microsoft_teams/faraday/retry_after.rb
@@ -92,7 +92,7 @@ module Legion
             total_wait        = 0.0
             last_advertised   = nil
 
-            loop do
+            (@max_retries + 1).times do
               response = @app.call(env.dup)
               return response unless retryable?(response.status)
 

--- a/lib/legion/extensions/microsoft_teams/helpers/client.rb
+++ b/lib/legion/extensions/microsoft_teams/helpers/client.rb
@@ -12,7 +12,7 @@ module Legion
           include Legion::Extensions::Helpers::Lex if Legion::Extensions.const_defined?(:Helpers, false) &&
                                                       Legion::Extensions::Helpers.const_defined?(:Lex, false)
 
-          def graph_connection(token: nil, api_url: 'https://graph.microsoft.com/v1.0', **_opts)
+          def graph_connection(token: nil, api_url: 'https://graph.microsoft.com/v1.0', **)
             token ||= entra_delegated_token
             ::Faraday.new(url: api_url) do |conn|
               conn.request :json
@@ -24,7 +24,7 @@ module Legion
             end
           end
 
-          def bot_connection(token: nil, service_url: 'https://smba.trafficmanager.net/teams/', **_opts)
+          def bot_connection(token: nil, service_url: 'https://smba.trafficmanager.net/teams/', **)
             ::Faraday.new(url: service_url) do |conn|
               conn.request :json
               conn.use Legion::Extensions::MicrosoftTeams::Faraday::ThrottleCircuit, **throttle_circuit_options
@@ -39,7 +39,7 @@ module Legion
             user_id == 'me' ? 'me' : "users/#{user_id}"
           end
 
-          def oauth_connection(tenant_id: 'common', **_opts)
+          def oauth_connection(tenant_id: 'common', **)
             ::Faraday.new(url: "https://login.microsoftonline.com/#{tenant_id}") do |conn|
               conn.request :url_encoded
               conn.response :json, content_type: /\bjson$/
@@ -51,7 +51,7 @@ module Legion
           def entra_delegated_token
             Legion::Extensions::Identity::Entra::Helpers::TokenManager.load_token(:delegated)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'Client#entra_delegated_token')
+            handle_exception(e, level: :warn, operation: 'Client#entra_delegated_token')
             nil
           end
 

--- a/lib/legion/extensions/microsoft_teams/helpers/graph_cache.rb
+++ b/lib/legion/extensions/microsoft_teams/helpers/graph_cache.rb
@@ -21,7 +21,7 @@ module Legion
               resp.body
             end
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'GraphCache#cached_graph_get', path: path)
+            handle_exception(e, level: :warn, operation: 'GraphCache#cached_graph_get', path: path)
             conn.get(path, params).body
           end
 
@@ -35,7 +35,7 @@ module Legion
             key = graph_cache_key(path: path, params: params, shared: shared)
             cache_delete(key)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'GraphCache#invalidate_graph_cache')
+            handle_exception(e, level: :warn, operation: 'GraphCache#invalidate_graph_cache')
           end
 
           private
@@ -55,7 +55,7 @@ module Legion
 
             Legion::Settings[:microsoft_teams] || {}
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'GraphCache#teams_extension_settings')
+            handle_exception(e, level: :warn, operation: 'GraphCache#teams_extension_settings')
             {}
           end
         end

--- a/lib/legion/extensions/microsoft_teams/helpers/graph_client.rb
+++ b/lib/legion/extensions/microsoft_teams/helpers/graph_client.rb
@@ -21,7 +21,7 @@ module Legion
             next_link = nil
             page      = 0
 
-            loop do
+            max_pages.times do
               current_path = next_link || path
               data         = graph_get(current_path, token: token, params: page.zero? ? params : {})
               break if data.nil?

--- a/lib/legion/extensions/microsoft_teams/helpers/high_water_mark.rb
+++ b/lib/legion/extensions/microsoft_teams/helpers/high_water_mark.rb
@@ -59,7 +59,7 @@ module Legion
 
             raw.is_a?(Hash) ? raw : ::JSON.parse(raw, symbolize_names: true)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'HighWaterMark#get_extended_hwm',
+            handle_exception(e, level: :warn, operation: 'HighWaterMark#get_extended_hwm',
                              chat_id: chat_id)
             nil
           end

--- a/lib/legion/extensions/microsoft_teams/helpers/prompt_resolver.rb
+++ b/lib/legion/extensions/microsoft_teams/helpers/prompt_resolver.rb
@@ -55,7 +55,7 @@ module Legion
             Legion::Extensions::Mesh::Helpers::PreferenceProfile.preference_instructions(profile: profile)
           rescue StandardError => e
             if defined?(handle_exception)
-              handle_exception(e, level: :debug, operation: 'PromptResolver#preference_instructions_for',
+              handle_exception(e, level: :warn, operation: 'PromptResolver#preference_instructions_for',
                                owner_id: owner_id)
             end
             nil

--- a/lib/legion/extensions/microsoft_teams/helpers/session_manager.rb
+++ b/lib/legion/extensions/microsoft_teams/helpers/session_manager.rb
@@ -153,7 +153,7 @@ module Legion
             profile_traces.map { |t| { type: t[:trace_type], content: t[:content_payload].to_s[0, 200] } }
           rescue StandardError => e
             if defined?(handle_exception)
-              handle_exception(e, level: :debug, operation: 'SessionManager#trace_seed_for',
+              handle_exception(e, level: :warn, operation: 'SessionManager#trace_seed_for',
                                owner_id: owner_id)
             end
             nil

--- a/lib/legion/extensions/microsoft_teams/helpers/trace_retriever.rb
+++ b/lib/legion/extensions/microsoft_teams/helpers/trace_retriever.rb
@@ -131,7 +131,7 @@ module Legion
             return unless defined?(log)
 
             if defined?(handle_exception)
-              handle_exception(error, level: :debug, operation: "TraceRetriever##{method}")
+              handle_exception(error, level: :warn, operation: "TraceRetriever##{method}")
             else
               log.debug("TraceRetriever##{method} failed: #{error.message}")
             end

--- a/lib/legion/extensions/microsoft_teams/local_cache/sstable_reader.rb
+++ b/lib/legion/extensions/microsoft_teams/local_cache/sstable_reader.rb
@@ -102,7 +102,7 @@ module Legion
           def decode_varint(data, pos)
             result = 0
             shift = 0
-            loop do
+            10.times do # varint max 10 bytes (64-bit)
               return [nil, pos] if pos >= data.bytesize
 
               byte = data.getbyte(pos)

--- a/lib/legion/extensions/microsoft_teams/runners/api_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/api_ingest.rb
@@ -22,16 +22,12 @@ module Legion
 
           definition :ingest_api, mcp_exposed: false
 
-          # Fetch top contacts via /me/people, then pull recent messages from
-          # their 1:1 chats. Stores each message as an individual memory trace
-          # (same format as CacheIngest) with dedup by content hash.
-          #
-          # Requires a delegated token with Chat.Read and People.Read scopes.
           def ingest_api(token:, top_people: 15, message_depth: 50, skip_bots: true, imprint_active: false, **) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
             log.debug("ApiIngest#ingest_api top_people=#{top_people} message_depth=#{message_depth}")
             return error_result('lex-memory not loaded') unless memory_available?
             return error_result('no token provided') unless token && !token.empty?
 
+            @fetch_failures = 0
             restore_hwm_from_traces
 
             people = fetch_top_people(token: token, top: top_people)
@@ -104,6 +100,7 @@ module Legion
 
             { result: { stored: stored, skipped: skipped, people_ingested: people_ingested,
                         people_found: people.length, chats_found: chats.length,
+                        fetch_failures: @fetch_failures,
                         apollo: apollo_results } }
           # rubocop:disable Legion/RescueLogging/NoCapture
           # Re-raise unlogged: surface the typed throttle to the caller (the
@@ -117,7 +114,8 @@ module Legion
             # rubocop:enable Legion/RescueLogging/NoCapture
           rescue StandardError => e
             handle_exception(e, level: :error, operation: 'ApiIngest#ingest_api')
-            { result: { stored: stored || 0, skipped: skipped || 0, error: e.message } }
+            { result: { stored: stored || 0, skipped: skipped || 0,
+                        fetch_failures: @fetch_failures || 0, error: e.message } }
           end
 
           include Legion::Extensions::Helpers::Lex if Legion::Extensions.const_defined?(:Helpers, false) &&
@@ -135,15 +133,22 @@ module Legion
             resp = conn.get('me/people', { '$top' => top })
 
             log.debug("ApiIngest: fetch_top_people status=#{resp.status} count=#{(resp.body || {}).fetch('value', []).size}")
-            if resp.status == 403
-              record_denial('/me/people', resp.body.dig('error', 'message') || 'Forbidden')
+            unless (200..299).cover?(resp.status)
+              error_code = resp.body&.dig('error', 'code')
+              log.warn("[microsoft_teams][api_ingest] fetch_top_people non-2xx: " \
+                       "status=#{resp.status} error_code=#{error_code}")
+              record_denial('/me/people', resp.body&.dig('error', 'message') || 'Forbidden') if resp.status == 403
+              @fetch_failures = (@fetch_failures || 0) + 1
               return []
             end
 
             people = (resp.body || {}).fetch('value', [])
             people.sort_by { |p| -(p.dig('scoredEmailAddresses', 0, 'relevanceScore') || 0) }
+          rescue Errors::Throttled
+            raise
           rescue StandardError => e
             handle_exception(e, level: :warn, operation: 'ApiIngest#fetch_top_people')
+            @fetch_failures = (@fetch_failures || 0) + 1
             []
           end
 
@@ -156,6 +161,15 @@ module Legion
 
             loop do
               resp = conn.get(url, params)
+
+              unless (200..299).cover?(resp.status)
+                error_code = resp.body&.dig('error', 'code')
+                log.warn("[microsoft_teams][api_ingest] fetch_one_on_one_chats non-2xx: " \
+                         "status=#{resp.status} error_code=#{error_code}")
+                @fetch_failures = (@fetch_failures || 0) + 1
+                break
+              end
+
               body = resp.body || {}
               chats = body.fetch('value', [])
               all_chats.concat(chats)
@@ -173,8 +187,11 @@ module Legion
             filtered = all_chats.select { |c| allowed_types.include?(c['chatType']) }
             log.info("ApiIngest: fetched #{all_chats.size} chats (#{pages} pages), #{filtered.size} eligible (1:1/group/meeting)")
             filtered
+          rescue Errors::Throttled
+            raise
           rescue StandardError => e
             handle_exception(e, level: :warn, operation: 'ApiIngest#fetch_one_on_one_chats')
+            @fetch_failures = (@fetch_failures || 0) + 1
             []
           end
 
@@ -201,8 +218,11 @@ module Legion
             end
 
             { email: by_email, user_id: by_user_id, name: by_name }
+          rescue Errors::Throttled
+            raise
           rescue StandardError => e
             handle_exception(e, level: :warn, operation: 'ApiIngest#build_chat_member_index')
+            @fetch_failures = (@fetch_failures || 0) + 1
             { email: {}, user_id: {}, name: {} }
           end
 
@@ -222,11 +242,23 @@ module Legion
             params['$filter'] = "createdDateTime gt #{hwm[:last_message_at]}" if hwm&.dig(:last_message_at)
 
             resp = conn.get("chats/#{chat_id}/messages", params)
+
+            unless (200..299).cover?(resp.status)
+              error_code = resp.body&.dig('error', 'code')
+              log.warn("[microsoft_teams][api_ingest] fetch_chat_messages non-2xx: " \
+                       "chat_id=#{chat_id} status=#{resp.status} error_code=#{error_code}")
+              @fetch_failures = (@fetch_failures || 0) + 1
+              return []
+            end
+
             log.debug("ApiIngest: fetch_messages chat=#{chat_id} count=#{(resp.body || {}).fetch('value', []).size}")
             (resp.body || {}).fetch('value', [])
+          rescue Errors::Throttled
+            raise
           rescue StandardError => e
             handle_exception(e, level: :warn, operation: 'ApiIngest#fetch_chat_messages',
                              chat_id: chat_id)
+            @fetch_failures = (@fetch_failures || 0) + 1
             []
           end
 

--- a/lib/legion/extensions/microsoft_teams/runners/api_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/api_ingest.rb
@@ -162,7 +162,7 @@ module Legion
             params = { '$top' => 50 }
             pages = 0
 
-            loop do
+            MAX_CHAT_PAGES.times do
               resp = conn.get(url, params)
 
               unless (200..299).cover?(resp.status)
@@ -180,7 +180,6 @@ module Legion
 
               next_link = body['@odata.nextLink']
               break unless next_link
-              break if pages >= MAX_CHAT_PAGES
 
               url = next_link
               params = {}
@@ -347,7 +346,7 @@ module Legion
             end
             hashes
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'ApiIngest#load_existing_hashes')
+            handle_exception(e, level: :warn, operation: 'ApiIngest#load_existing_hashes')
             Set.new
           end
 
@@ -376,12 +375,12 @@ module Legion
               trace_ids.each_cons(2) do |id_a, id_b|
                 store.record_coactivation(id_a, id_b)
               rescue StandardError => e
-                handle_exception(e, level: :debug, operation: 'ApiIngest#coactivate_thread_traces',
+                handle_exception(e, level: :warn, operation: 'ApiIngest#coactivate_thread_traces',
                                  id_a: id_a, id_b: id_b)
               end
             end
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'ApiIngest#coactivate_thread_traces')
+            handle_exception(e, level: :warn, operation: 'ApiIngest#coactivate_thread_traces')
           end
 
           def publish_to_apollo(person_texts)
@@ -440,7 +439,7 @@ module Legion
 
             { success: true, count: result[:entities].length }
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'ApiIngest#extract_and_ingest_entities',
+            handle_exception(e, level: :warn, operation: 'ApiIngest#extract_and_ingest_entities',
                              person_name: person_name)
             { success: false, count: 0 }
           end

--- a/lib/legion/extensions/microsoft_teams/runners/api_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/api_ingest.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'digest'
+require 'set'
 require 'legion/extensions/microsoft_teams/errors'
 require 'legion/extensions/microsoft_teams/helpers/client'
 require 'legion/extensions/microsoft_teams/helpers/graph_cache'
@@ -236,10 +237,18 @@ module Legion
               chat_index[:name][display_name]
           end
 
+          def hwm_client_side_cut(messages:, hwm:)
+            return messages unless hwm&.dig(:last_message_at)
+
+            cutoff = hwm[:last_message_at]
+            seen = Set.new
+            messages.take_while { |m| m['createdDateTime'] && m['createdDateTime'] > cutoff }
+                    .reject { |m| !seen.add?(m['id'] || Digest::SHA256.hexdigest(m.dig('body', 'content').to_s)[0, 16]) }
+          end
+
           def fetch_chat_messages(conn:, chat_id:, depth: 50)
             hwm = get_extended_hwm(chat_id: chat_id)
             params = { '$top' => depth, '$orderby' => 'createdDateTime desc' }
-            params['$filter'] = "createdDateTime gt #{hwm[:last_message_at]}" if hwm&.dig(:last_message_at)
 
             resp = conn.get("chats/#{chat_id}/messages", params)
 
@@ -251,8 +260,10 @@ module Legion
               return []
             end
 
-            log.debug("ApiIngest: fetch_messages chat=#{chat_id} count=#{(resp.body || {}).fetch('value', []).size}")
-            (resp.body || {}).fetch('value', [])
+            messages = (resp.body || {}).fetch('value', [])
+            messages = hwm_client_side_cut(messages: messages, hwm: hwm)
+            log.debug("ApiIngest: fetch_messages chat=#{chat_id} count=#{messages.size}")
+            messages
           rescue Errors::Throttled
             raise
           rescue StandardError => e

--- a/lib/legion/extensions/microsoft_teams/runners/api_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/api_ingest.rb
@@ -196,14 +196,17 @@ module Legion
             []
           end
 
+          CHAT_TYPE_PRIORITY = { 'oneOnOne' => 0, 'group' => 1, 'meeting' => 2 }.freeze
+
           def build_chat_member_index(conn:, chats:)
             by_email = {}
             by_user_id = {}
             by_name = {}
 
-            chats.each do |chat|
+            sorted = chats.sort_by { |c| CHAT_TYPE_PRIORITY[c['chatType']] || 99 }
+            sorted.each do |chat|
               members = cached_graph_get(conn: conn, path: "chats/#{chat['id']}/members",
-                                         shared: true)
+                                         shared: true, ttl: members_cache_ttl)
                         .then { |body| (body || {}).fetch('value', []) }
               members.each do |m|
                 email = m['email']&.downcase
@@ -448,6 +451,16 @@ module Legion
 
           def apollo_knowledge_runner
             @apollo_knowledge_runner ||= Object.new.extend(Legion::Extensions::Apollo::Runners::Knowledge)
+          end
+
+          def members_cache_ttl
+            return @members_cache_ttl if defined?(@members_cache_ttl)
+
+            @members_cache_ttl = if respond_to?(:settings, true) && settings.respond_to?(:dig)
+                                   settings.dig(:cache, :members_ttl) || 86_400
+                                 else
+                                   86_400
+                                 end
           end
 
           def error_result(message)

--- a/lib/legion/extensions/microsoft_teams/runners/api_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/api_ingest.rb
@@ -2,7 +2,6 @@
 
 require 'json'
 require 'digest'
-require 'set'
 require 'legion/extensions/microsoft_teams/errors'
 require 'legion/extensions/microsoft_teams/helpers/client'
 require 'legion/extensions/microsoft_teams/helpers/graph_cache'
@@ -123,6 +122,7 @@ module Legion
                                                       Legion::Extensions::Helpers.const_defined?(:Lex, false)
 
           MAX_CHAT_PAGES = 10
+          CHAT_TYPE_PRIORITY = { 'oneOnOne' => 0, 'group' => 1, 'meeting' => 2 }.freeze
 
           private
 
@@ -136,7 +136,7 @@ module Legion
             log.debug("ApiIngest: fetch_top_people status=#{resp.status} count=#{(resp.body || {}).fetch('value', []).size}")
             unless (200..299).cover?(resp.status)
               error_code = resp.body&.dig('error', 'code')
-              log.warn("[microsoft_teams][api_ingest] fetch_top_people non-2xx: " \
+              log.warn('[microsoft_teams][api_ingest] fetch_top_people non-2xx: ' \
                        "status=#{resp.status} error_code=#{error_code}")
               record_denial('/me/people', resp.body&.dig('error', 'message') || 'Forbidden') if resp.status == 403
               @fetch_failures = (@fetch_failures || 0) + 1
@@ -145,8 +145,10 @@ module Legion
 
             people = (resp.body || {}).fetch('value', [])
             people.sort_by { |p| -(p.dig('scoredEmailAddresses', 0, 'relevanceScore') || 0) }
+          # rubocop:disable Legion/RescueLogging/NoCapture
           rescue Errors::Throttled
             raise
+            # rubocop:enable Legion/RescueLogging/NoCapture
           rescue StandardError => e
             handle_exception(e, level: :warn, operation: 'ApiIngest#fetch_top_people')
             @fetch_failures = (@fetch_failures || 0) + 1
@@ -165,7 +167,7 @@ module Legion
 
               unless (200..299).cover?(resp.status)
                 error_code = resp.body&.dig('error', 'code')
-                log.warn("[microsoft_teams][api_ingest] fetch_one_on_one_chats non-2xx: " \
+                log.warn('[microsoft_teams][api_ingest] fetch_one_on_one_chats non-2xx: ' \
                          "status=#{resp.status} error_code=#{error_code}")
                 @fetch_failures = (@fetch_failures || 0) + 1
                 break
@@ -188,15 +190,15 @@ module Legion
             filtered = all_chats.select { |c| allowed_types.include?(c['chatType']) }
             log.info("ApiIngest: fetched #{all_chats.size} chats (#{pages} pages), #{filtered.size} eligible (1:1/group/meeting)")
             filtered
+          # rubocop:disable Legion/RescueLogging/NoCapture
           rescue Errors::Throttled
             raise
+            # rubocop:enable Legion/RescueLogging/NoCapture
           rescue StandardError => e
             handle_exception(e, level: :warn, operation: 'ApiIngest#fetch_one_on_one_chats')
             @fetch_failures = (@fetch_failures || 0) + 1
             []
           end
-
-          CHAT_TYPE_PRIORITY = { 'oneOnOne' => 0, 'group' => 1, 'meeting' => 2 }.freeze
 
           def build_chat_member_index(conn:, chats:)
             by_email = {}
@@ -222,8 +224,10 @@ module Legion
             end
 
             { email: by_email, user_id: by_user_id, name: by_name }
+          # rubocop:disable Legion/RescueLogging/NoCapture
           rescue Errors::Throttled
             raise
+            # rubocop:enable Legion/RescueLogging/NoCapture
           rescue StandardError => e
             handle_exception(e, level: :warn, operation: 'ApiIngest#build_chat_member_index')
             @fetch_failures = (@fetch_failures || 0) + 1
@@ -246,7 +250,7 @@ module Legion
             cutoff = hwm[:last_message_at]
             seen = Set.new
             messages.take_while { |m| m['createdDateTime'] && m['createdDateTime'] > cutoff }
-                    .reject { |m| !seen.add?(m['id'] || Digest::SHA256.hexdigest(m.dig('body', 'content').to_s)[0, 16]) }
+                    .select { |m| seen.add?(m['id'] || Digest::SHA256.hexdigest(m.dig('body', 'content').to_s)[0, 16]) }
           end
 
           def fetch_chat_messages(conn:, chat_id:, depth: 50)
@@ -257,7 +261,7 @@ module Legion
 
             unless (200..299).cover?(resp.status)
               error_code = resp.body&.dig('error', 'code')
-              log.warn("[microsoft_teams][api_ingest] fetch_chat_messages non-2xx: " \
+              log.warn('[microsoft_teams][api_ingest] fetch_chat_messages non-2xx: ' \
                        "chat_id=#{chat_id} status=#{resp.status} error_code=#{error_code}")
               @fetch_failures = (@fetch_failures || 0) + 1
               return []
@@ -267,8 +271,10 @@ module Legion
             messages = hwm_client_side_cut(messages: messages, hwm: hwm)
             log.debug("ApiIngest: fetch_messages chat=#{chat_id} count=#{messages.size}")
             messages
+          # rubocop:disable Legion/RescueLogging/NoCapture
           rescue Errors::Throttled
             raise
+            # rubocop:enable Legion/RescueLogging/NoCapture
           rescue StandardError => e
             handle_exception(e, level: :warn, operation: 'ApiIngest#fetch_chat_messages',
                              chat_id: chat_id)

--- a/lib/legion/extensions/microsoft_teams/runners/bot.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/bot.rb
@@ -200,7 +200,7 @@ module Legion
 
             retrieve_context(message: message, owner_id: owner_id, chat_id: chat_id)
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'Bot#retrieve_trace_context') if defined?(handle_exception)
+            handle_exception(e, level: :warn, operation: 'Bot#retrieve_trace_context') if defined?(handle_exception)
             nil
           end
 
@@ -231,7 +231,7 @@ module Legion
             Legion::Settings.dig(:microsoft_teams, :bot, :observe, :enabled) == true
           end
 
-          def notify_enabled?(**_kwargs)
+          def notify_enabled?(**)
             return false unless defined?(Legion::Settings)
 
             Legion::Settings.dig(:microsoft_teams, :bot, :observe, :notify) == true

--- a/lib/legion/extensions/microsoft_teams/runners/cache_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/cache_ingest.rb
@@ -123,12 +123,12 @@ module Legion
               trace_ids.each_cons(2) do |id_a, id_b|
                 store.record_coactivation(id_a, id_b)
               rescue StandardError => e
-                handle_exception(e, level: :debug, operation: 'CacheIngest#coactivate_thread_traces',
+                handle_exception(e, level: :warn, operation: 'CacheIngest#coactivate_thread_traces',
                                  id_a: id_a, id_b: id_b)
               end
             end
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'CacheIngest#coactivate_thread_traces')
+            handle_exception(e, level: :warn, operation: 'CacheIngest#coactivate_thread_traces')
           end
         end
       end

--- a/lib/legion/extensions/microsoft_teams/runners/profile_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/profile_ingest.rb
@@ -56,7 +56,7 @@ module Legion
             presence = begin
               conn.get('me/presence').body
             rescue StandardError => e
-              handle_exception(e, level: :debug, operation: 'ProfileIngest#ingest_self presence') if defined?(handle_exception)
+              handle_exception(e, level: :warn, operation: 'ProfileIngest#ingest_self presence') if defined?(handle_exception)
               {}
             end
 
@@ -319,7 +319,7 @@ module Legion
               llm_ask(message: "#{definition[:prompt]}\n\nConversation with #{peer_name}:\n#{text}")
             end
           rescue StandardError => e
-            handle_exception(e, level: :debug, operation: 'ProfileIngest#extract_conversation')
+            handle_exception(e, level: :warn, operation: 'ProfileIngest#extract_conversation')
             nil
           end
 

--- a/lib/legion/extensions/microsoft_teams/runners/profile_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/profile_ingest.rb
@@ -279,6 +279,15 @@ module Legion
             params['$filter'] = "createdDateTime gt #{hwm[:last_message_at]}" if hwm&.dig(:last_message_at)
 
             resp = conn.get("chats/#{chat_id}/messages", params)
+
+            unless (200..299).cover?(resp.status)
+              error_code = resp.body&.dig('error', 'code')
+              log.warn("[microsoft_teams][profile_ingest] fetch_new_messages non-2xx: " \
+                       "chat_id=#{chat_id} status=#{resp.status} error_code=#{error_code}")
+              @fetch_failures = (@fetch_failures || 0) + 1
+              return []
+            end
+
             (resp.body || {}).fetch('value', [])
           # rubocop:disable Legion/RescueLogging/NoCapture
           # Re-raise unlogged: propagate to full_ingest so the per-chat
@@ -289,6 +298,7 @@ module Legion
           rescue StandardError => e
             handle_exception(e, level: :warn, operation: 'ProfileIngest#fetch_new_messages',
                              chat_id: chat_id)
+            @fetch_failures = (@fetch_failures || 0) + 1
             []
           end
 

--- a/lib/legion/extensions/microsoft_teams/runners/profile_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/profile_ingest.rb
@@ -2,7 +2,6 @@
 
 require 'json'
 require 'digest'
-require 'set'
 require 'legion/extensions/microsoft_teams/errors'
 require 'legion/extensions/microsoft_teams/helpers/client'
 require 'legion/extensions/microsoft_teams/helpers/graph_cache'
@@ -221,9 +220,9 @@ module Legion
                                  top_people: top_people, message_depth: message_depth)
           end
 
-          private
-
           CHAT_TYPE_PRIORITY = { 'oneOnOne' => 0, 'group' => 1, 'meeting' => 2 }.freeze
+
+          private
 
           def build_chat_member_index(conn:, chats:)
             index = {}
@@ -267,7 +266,7 @@ module Legion
 
             unless (200..299).cover?(resp.status)
               error_code = resp.body&.dig('error', 'code')
-              log.warn("[microsoft_teams][profile_ingest] fetch_new_messages non-2xx: " \
+              log.warn('[microsoft_teams][profile_ingest] fetch_new_messages non-2xx: ' \
                        "chat_id=#{chat_id} status=#{resp.status} error_code=#{error_code}")
               @fetch_failures = (@fetch_failures || 0) + 1
               return []
@@ -294,7 +293,7 @@ module Legion
             cutoff = hwm[:last_message_at]
             seen = Set.new
             messages.take_while { |m| m['createdDateTime'] && m['createdDateTime'] > cutoff }
-                    .reject { |m| !seen.add?(m['id'] || Digest::SHA256.hexdigest(m.dig('body', 'content').to_s)[0, 16]) }
+                    .select { |m| seen.add?(m['id'] || Digest::SHA256.hexdigest(m.dig('body', 'content').to_s)[0, 16]) }
           end
 
           def extract_conversation(messages:, peer_name:)

--- a/lib/legion/extensions/microsoft_teams/runners/profile_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/profile_ingest.rb
@@ -54,28 +54,11 @@ module Legion
             conn = graph_connection(token: token)
             profile = conn.get('me').body
 
-            memory_runner.store_trace(
-              type:            :identity,
-              content_payload: ::JSON.dump(profile),
-              domain_tags:     %w[teams self owner],
-              confidence:      1.0,
-              origin:          :direct_experience
-            )
-
             presence = begin
               conn.get('me/presence').body
             rescue StandardError => e
               handle_exception(e, level: :debug, operation: 'ProfileIngest#ingest_self presence') if defined?(handle_exception)
               {}
-            end
-            unless presence.empty?
-              memory_runner.store_trace(
-                type:            :sensory,
-                content_payload: ::JSON.dump(presence),
-                domain_tags:     %w[teams presence self],
-                confidence:      0.8,
-                origin:          :direct_experience
-              )
             end
 
             { profile: profile, presence: presence }
@@ -104,18 +87,6 @@ module Legion
 
             people = (resp.body || {}).fetch('value', [])
             people.sort_by! { |p| -(p.dig('scoredEmailAddresses', 0, 'relevanceScore') || 0) }
-
-            people.each do |person|
-              name = person['displayName'] || 'Unknown'
-              memory_runner.store_trace(
-                type:            :semantic,
-                content_payload: ::JSON.dump(person.slice('displayName', 'jobTitle', 'department',
-                                                          'officeLocation', 'scoredEmailAddresses')),
-                domain_tags:     ['teams', 'peer', "peer:#{name}"],
-                confidence:      0.7,
-                origin:          :direct_experience
-              )
-            end
 
             { people: people, count: people.length }
           # rubocop:disable Legion/RescueLogging/NoCapture

--- a/lib/legion/extensions/microsoft_teams/runners/profile_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/profile_ingest.rb
@@ -252,11 +252,14 @@ module Legion
 
           private
 
+          CHAT_TYPE_PRIORITY = { 'oneOnOne' => 0, 'group' => 1, 'meeting' => 2 }.freeze
+
           def build_chat_member_index(conn:, chats:)
             index = {}
-            chats.each do |chat|
+            sorted = chats.sort_by { |c| CHAT_TYPE_PRIORITY[c['chatType']] || 99 }
+            sorted.each do |chat|
               members = cached_graph_get(conn: conn, path: "chats/#{chat['id']}/members",
-                                         shared: true)
+                                         shared: true, ttl: members_cache_ttl)
                         .then { |body| (body || {}).fetch('value', []) }
               members.each do |m|
                 email = m['email']&.downcase
@@ -273,6 +276,16 @@ module Legion
           rescue StandardError => e
             handle_exception(e, level: :warn, operation: 'ProfileIngest#build_chat_member_index')
             {}
+          end
+
+          def members_cache_ttl
+            return @members_cache_ttl if defined?(@members_cache_ttl)
+
+            @members_cache_ttl = if respond_to?(:settings, true) && settings.respond_to?(:dig)
+                                   settings.dig(:cache, :members_ttl) || 86_400
+                                 else
+                                   86_400
+                                 end
           end
 
           def fetch_new_messages(conn:, chat_id:, depth: 50)

--- a/lib/legion/extensions/microsoft_teams/runners/profile_ingest.rb
+++ b/lib/legion/extensions/microsoft_teams/runners/profile_ingest.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'digest'
+require 'set'
 require 'legion/extensions/microsoft_teams/errors'
 require 'legion/extensions/microsoft_teams/helpers/client'
 require 'legion/extensions/microsoft_teams/helpers/graph_cache'
@@ -276,7 +278,6 @@ module Legion
           def fetch_new_messages(conn:, chat_id:, depth: 50)
             hwm = get_extended_hwm(chat_id: chat_id)
             params = { '$top' => depth, '$orderby' => 'createdDateTime desc' }
-            params['$filter'] = "createdDateTime gt #{hwm[:last_message_at]}" if hwm&.dig(:last_message_at)
 
             resp = conn.get("chats/#{chat_id}/messages", params)
 
@@ -288,7 +289,8 @@ module Legion
               return []
             end
 
-            (resp.body || {}).fetch('value', [])
+            messages = (resp.body || {}).fetch('value', [])
+            hwm_client_side_cut(messages: messages, hwm: hwm)
           # rubocop:disable Legion/RescueLogging/NoCapture
           # Re-raise unlogged: propagate to full_ingest so the per-chat
           # fan-out stops on the first throttle; full_ingest logs it once.
@@ -300,6 +302,15 @@ module Legion
                              chat_id: chat_id)
             @fetch_failures = (@fetch_failures || 0) + 1
             []
+          end
+
+          def hwm_client_side_cut(messages:, hwm:)
+            return messages unless hwm&.dig(:last_message_at)
+
+            cutoff = hwm[:last_message_at]
+            seen = Set.new
+            messages.take_while { |m| m['createdDateTime'] && m['createdDateTime'] > cutoff }
+                    .reject { |m| !seen.add?(m['id'] || Digest::SHA256.hexdigest(m.dig('body', 'content').to_s)[0, 16]) }
           end
 
           def extract_conversation(messages:, peer_name:)

--- a/lib/legion/extensions/microsoft_teams/version.rb
+++ b/lib/legion/extensions/microsoft_teams/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module MicrosoftTeams
-      VERSION = '0.6.52'
+      VERSION = '0.6.53'
     end
   end
 end

--- a/spec/legion/extensions/microsoft_teams/integration/throttle_flow_spec.rb
+++ b/spec/legion/extensions/microsoft_teams/integration/throttle_flow_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Throttle flow integration' do
       # Override the connection builder to inject a captured sleeper +
       # deterministic Faraday test adapter while keeping the production
       # middleware stack intact.
-      def graph_connection(token: nil, api_url: 'https://graph.microsoft.com/v1.0', **_opts)
+      def graph_connection(token: nil, api_url: 'https://graph.microsoft.com/v1.0', **)
         token ||= 'integration-token'
 
         Faraday.new(url: api_url) do |conn|

--- a/spec/legion/extensions/microsoft_teams/runners/api_ingest_spec.rb
+++ b/spec/legion/extensions/microsoft_teams/runners/api_ingest_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe Legion::Extensions::MicrosoftTeams::Runners::ApiIngest do
       let(:forbidden_resp) do
         instance_double(Faraday::Response,
                         status: 403,
-                        body: { 'error' => { 'code' => 'Authorization_RequestDenied',
-                                             'message' => 'Insufficient privileges' } })
+                        body:   { 'error' => { 'code'    => 'Authorization_RequestDenied',
+                                               'message' => 'Insufficient privileges' } })
       end
 
       before do
@@ -96,8 +96,8 @@ RSpec.describe Legion::Extensions::MicrosoftTeams::Runners::ApiIngest do
       let(:not_found_resp) do
         instance_double(Faraday::Response,
                         status: 404,
-                        body: { 'error' => { 'code' => 'ResourceNotFound',
-                                             'message' => 'Chat not found' } })
+                        body:   { 'error' => { 'code'    => 'ResourceNotFound',
+                                               'message' => 'Chat not found' } })
       end
 
       before do
@@ -121,19 +121,19 @@ RSpec.describe Legion::Extensions::MicrosoftTeams::Runners::ApiIngest do
       let(:people_resp) do
         instance_double(Faraday::Response,
                         status: 200,
-                        body: { 'value' => [{ 'displayName' => 'Bob',
-                                              'scoredEmailAddresses' => [{ 'address' => 'bob@test.com', 'relevanceScore' => 8 }],
-                                              'id' => 'user-1' }] })
+                        body:   { 'value' => [{ 'displayName'          => 'Bob',
+                                                'scoredEmailAddresses' => [{ 'address' => 'bob@test.com', 'relevanceScore' => 8 }],
+                                                'id'                   => 'user-1' }] })
       end
       let(:chats_resp) do
         instance_double(Faraday::Response,
                         status: 200,
-                        body: { 'value' => [{ 'id' => 'chat-1', 'chatType' => 'oneOnOne' }] })
+                        body:   { 'value' => [{ 'id' => 'chat-1', 'chatType' => 'oneOnOne' }] })
       end
       let(:messages_403_resp) do
         instance_double(Faraday::Response,
                         status: 403,
-                        body: { 'error' => { 'code' => 'Forbidden', 'message' => 'Access denied' } })
+                        body:   { 'error' => { 'code' => 'Forbidden', 'message' => 'Access denied' } })
       end
 
       before do

--- a/spec/legion/extensions/microsoft_teams/runners/api_ingest_spec.rb
+++ b/spec/legion/extensions/microsoft_teams/runners/api_ingest_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Legion::Extensions::MicrosoftTeams::Runners::ApiIngest do
+  let(:runner) { Object.new.extend(described_class) }
+  let(:memory_runner) { double('memory_runner') }
+  let(:graph_conn) { instance_double(Faraday::Connection) }
+
+  before do
+    allow(runner).to receive(:memory_runner).and_return(memory_runner)
+    allow(memory_runner).to receive(:store_trace).and_return({ success: true, trace_id: 'trace-1' })
+    allow(memory_runner).to receive(:retrieve_by_domain).and_return([])
+    allow(runner).to receive(:graph_connection).and_return(graph_conn)
+    allow(runner).to receive(:permission_denied?).and_return(false)
+    allow(runner).to receive(:record_denial)
+    allow(runner).to receive(:cache_available?).and_return(false)
+  end
+
+  describe 'throttle propagation (A1)' do
+    let(:throttled_error) do
+      Legion::Extensions::MicrosoftTeams::Errors::Throttled.new(
+        status: 429, retry_after: 30.0, request: '/me/people'
+      )
+    end
+
+    context 'when fetch_top_people encounters Throttled' do
+      it 'raises Errors::Throttled instead of swallowing it' do
+        allow(graph_conn).to receive(:get).and_raise(throttled_error)
+
+        expect do
+          runner.send(:fetch_top_people, token: 'tok', top: 10)
+        end.to raise_error(Legion::Extensions::MicrosoftTeams::Errors::Throttled)
+      end
+    end
+
+    context 'when fetch_one_on_one_chats encounters Throttled' do
+      it 'raises Errors::Throttled instead of swallowing it' do
+        allow(graph_conn).to receive(:get).and_raise(throttled_error)
+
+        expect do
+          runner.send(:fetch_one_on_one_chats, token: 'tok')
+        end.to raise_error(Legion::Extensions::MicrosoftTeams::Errors::Throttled)
+      end
+    end
+
+    context 'when build_chat_member_index encounters Throttled' do
+      it 'raises Errors::Throttled instead of swallowing it' do
+        allow(runner).to receive(:cached_graph_get).and_raise(throttled_error)
+        chats = [{ 'id' => 'chat-1', 'chatType' => 'oneOnOne' }]
+
+        expect do
+          runner.send(:build_chat_member_index, conn: graph_conn, chats: chats)
+        end.to raise_error(Legion::Extensions::MicrosoftTeams::Errors::Throttled)
+      end
+    end
+
+    context 'when fetch_chat_messages encounters Throttled' do
+      it 'raises Errors::Throttled instead of swallowing it' do
+        allow(runner).to receive(:get_extended_hwm).and_return(nil)
+        allow(graph_conn).to receive(:get).and_raise(throttled_error)
+
+        expect do
+          runner.send(:fetch_chat_messages, conn: graph_conn, chat_id: 'chat-1')
+        end.to raise_error(Legion::Extensions::MicrosoftTeams::Errors::Throttled)
+      end
+    end
+  end
+
+  describe 'non-2xx status handling (A1)' do
+    context 'when fetch_top_people receives a 403' do
+      let(:forbidden_resp) do
+        instance_double(Faraday::Response,
+                        status: 403,
+                        body: { 'error' => { 'code' => 'Authorization_RequestDenied',
+                                             'message' => 'Insufficient privileges' } })
+      end
+
+      before do
+        allow(graph_conn).to receive(:get).and_return(forbidden_resp)
+      end
+
+      it 'returns an empty array' do
+        result = runner.send(:fetch_top_people, token: 'tok', top: 10)
+        expect(result).to eq([])
+      end
+
+      it 'increments fetch_failures' do
+        runner.instance_variable_set(:@fetch_failures, 0)
+        runner.send(:fetch_top_people, token: 'tok', top: 10)
+        expect(runner.instance_variable_get(:@fetch_failures)).to eq(1)
+      end
+    end
+
+    context 'when fetch_chat_messages receives a 404' do
+      let(:not_found_resp) do
+        instance_double(Faraday::Response,
+                        status: 404,
+                        body: { 'error' => { 'code' => 'ResourceNotFound',
+                                             'message' => 'Chat not found' } })
+      end
+
+      before do
+        allow(runner).to receive(:get_extended_hwm).and_return(nil)
+        allow(graph_conn).to receive(:get).and_return(not_found_resp)
+      end
+
+      it 'returns an empty array' do
+        result = runner.send(:fetch_chat_messages, conn: graph_conn, chat_id: 'chat-1')
+        expect(result).to eq([])
+      end
+
+      it 'increments fetch_failures' do
+        runner.instance_variable_set(:@fetch_failures, 0)
+        runner.send(:fetch_chat_messages, conn: graph_conn, chat_id: 'chat-1')
+        expect(runner.instance_variable_get(:@fetch_failures)).to eq(1)
+      end
+    end
+
+    context 'when ingest_api runs with fetch failures' do
+      let(:people_resp) do
+        instance_double(Faraday::Response,
+                        status: 200,
+                        body: { 'value' => [{ 'displayName' => 'Bob',
+                                              'scoredEmailAddresses' => [{ 'address' => 'bob@test.com', 'relevanceScore' => 8 }],
+                                              'id' => 'user-1' }] })
+      end
+      let(:chats_resp) do
+        instance_double(Faraday::Response,
+                        status: 200,
+                        body: { 'value' => [{ 'id' => 'chat-1', 'chatType' => 'oneOnOne' }] })
+      end
+      let(:messages_403_resp) do
+        instance_double(Faraday::Response,
+                        status: 403,
+                        body: { 'error' => { 'code' => 'Forbidden', 'message' => 'Access denied' } })
+      end
+
+      before do
+        allow(runner).to receive(:memory_available?).and_return(true)
+        allow(runner).to receive(:restore_hwm_from_traces)
+        allow(runner).to receive(:get_extended_hwm).and_return(nil)
+        allow(runner).to receive(:load_existing_hashes).and_return(Set.new)
+        allow(runner).to receive(:cached_graph_get).and_return(
+          { 'value' => [{ 'email' => 'bob@test.com', 'userId' => 'user-1', 'displayName' => 'Bob' }] }
+        )
+        allow(graph_conn).to receive(:get).with('me/people', anything).and_return(people_resp)
+        allow(graph_conn).to receive(:get).with('me/chats', anything).and_return(chats_resp)
+        allow(graph_conn).to receive(:get).with('chats/chat-1/messages', anything).and_return(messages_403_resp)
+      end
+
+      it 'includes fetch_failures in the result hash' do
+        result = runner.ingest_api(token: 'tok')
+        expect(result[:result][:fetch_failures]).to be >= 1
+      end
+    end
+  end
+end

--- a/spec/legion/extensions/microsoft_teams/runners/profile_ingest_spec.rb
+++ b/spec/legion/extensions/microsoft_teams/runners/profile_ingest_spec.rb
@@ -39,11 +39,8 @@ RSpec.describe Legion::Extensions::MicrosoftTeams::Runners::ProfileIngest do
       allow(presence_response).to receive(:body).and_return({})
     end
 
-    it 'stores an identity trace with self tags' do
-      expect(memory_runner).to receive(:store_trace).with(hash_including(
-                                                            type:        :identity,
-                                                            domain_tags: %w[teams self owner]
-                                                          ))
+    it 'does not store identity traces from API fetch (A4)' do
+      expect(memory_runner).not_to receive(:store_trace)
       runner.ingest_self(token: 'tok')
     end
 
@@ -66,10 +63,11 @@ RSpec.describe Legion::Extensions::MicrosoftTeams::Runners::ProfileIngest do
     before do
       allow(graph_conn).to receive(:get).with('me/people', anything).and_return(response)
       allow(response).to receive(:body).and_return(people_body)
+      allow(response).to receive(:status).and_return(200)
     end
 
-    it 'stores a semantic trace per person' do
-      expect(memory_runner).to receive(:store_trace).twice
+    it 'does not store traces from API fetch (A4)' do
+      expect(memory_runner).not_to receive(:store_trace)
       runner.ingest_people(token: 'tok', top: 25)
     end
 


### PR DESCRIPTION
## Summary
- A1: Throttle errors propagate (rescue Errors::Throttled before StandardError); fetch_failures counter
- A2: Invalid $filter=createdDateTime gt removed; client-side HWM cut with dedup
- A3: Member index chatType priority (1:1 > group > meeting); 24h members cache TTL
- A4: Stop writing Graph user objects as identity traces; stop reinforcing on API fetch

## Test plan
- [x] `bundle exec rspec` — 393 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses