### PR TITLE
chore(teams): document H4 preference migration deferral (awaiting OP3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.6.54] - 2026-07-16
+### Changed
+- **H4 preference convergence — deferred (awaiting OP3):** Investigated Teams `PromptResolver#preference_instructions_for` for H4 channel-agnostic advisory migration. Teams calls `Legion::LLM.chat` directly in `Bot#llm_respond`, bypassing the executor and advisory pipeline entirely. Removing the local `PreferenceProfile` injection now would silently drop partner-model preference context from every bot response. Removal is deferred until OP3 routes Teams through the executor (LegionIO/legion-gaia#40). Added TODO marker and deferral spec to document current behavior and migration acceptance criteria.
+
 ## [0.6.53] - 2026-07-15
 ### Fixed
 - Fix throttle propagation, invalid OData filter, member index priority, stop trace spam from API fetches

--- a/lib/legion/extensions/microsoft_teams/helpers/prompt_resolver.rb
+++ b/lib/legion/extensions/microsoft_teams/helpers/prompt_resolver.rb
@@ -47,6 +47,11 @@ module Legion
             nil
           end
 
+          # H4: Remove after OP3 lands (advisory path serves Teams).
+          # Teams calls Legion::LLM.chat directly (Bot#llm_respond) — it bypasses the legion-llm
+          # executor and advisory pipeline entirely. Until OP3 wires Teams through the executor,
+          # removing this local injection would silently drop preference context from bot responses.
+          # Track: LegionIO/legion-gaia#40
           def preference_instructions_for(owner_id:)
             return nil unless owner_id
             return nil unless defined?(Legion::Extensions::Mesh::Helpers::PreferenceProfile)

--- a/lib/legion/extensions/microsoft_teams/version.rb
+++ b/lib/legion/extensions/microsoft_teams/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module MicrosoftTeams
-      VERSION = '0.6.53'
+      VERSION = '0.6.54'
     end
   end
 end

--- a/spec/legion/extensions/microsoft_teams/helpers/prompt_resolver_spec.rb
+++ b/spec/legion/extensions/microsoft_teams/helpers/prompt_resolver_spec.rb
@@ -91,6 +91,39 @@ RSpec.describe Legion::Extensions::MicrosoftTeams::Helpers::PromptResolver do
     end
   end
 
+  # H4 migration deferral: Teams calls Legion::LLM.chat directly (Bot#llm_respond), bypassing
+  # the executor and advisory pipeline. The channel-local preference injection in
+  # preference_instructions_for MUST stay until OP3 routes Teams through the executor so the
+  # advisory path can serve partner_model slots.  Removing it now would silently drop preference
+  # context from every bot response.
+  #
+  # Verification: stub a Teams-channel request, confirm preference content appears in the prompt.
+  # If the advisory path ever serves Teams, this block becomes the removal acceptance test.
+  describe '#resolve_prompt H4 preference injection (deferred pending OP3)' do
+    it 'local injection is still present: preference content appears in resolved prompt' do
+      profile_mod = Legion::Extensions::Mesh::Helpers::PreferenceProfile
+      allow(profile_mod).to receive(:resolve).and_return(
+        { verbosity: :concise, tone: :formal, format: :structured,
+          technical_depth: :moderate, sources: [:explicit], resolved_at: Time.now }
+      )
+      allow(profile_mod).to receive(:preference_instructions).and_return(
+        'Keep responses brief. Use formal language.'
+      )
+
+      prompt = resolver.resolve_prompt(mode: :direct, conversation_id: '19:teams-chan', owner_id: 'u1')
+      expect(prompt).to include('brief')
+      expect(prompt).to include('formal')
+    end
+
+    it 'returns plain base prompt when owner_id absent — preference system skipped' do
+      # Documents that without owner_id (or when PreferenceProfile not loaded), the prompt
+      # is plain base text. This MUST NOT silently degrade if local injection is removed.
+      prompt = resolver.resolve_prompt(mode: :direct, conversation_id: '19:teams-chan')
+      expect(prompt).to be_a(String)
+      expect(prompt).not_to be_empty
+    end
+  end
+
   describe '#resolve_prompt with preferences' do
     it 'appends preference instructions when owner_id provided' do
       profile_mod = Legion::Extensions::Mesh::Helpers::PreferenceProfile


### PR DESCRIPTION
## Summary
- Investigated Teams `PromptResolver#preference_instructions_for` for H4 channel-agnostic advisory migration
- Advisory path does NOT yet serve Teams: `Bot#llm_respond` calls `Legion::LLM.chat` directly, bypassing the executor and advisory pipeline entirely
- Removal deferred to Phase LLM per H4 blackout prevention amendment — removing now would silently drop preference context from every bot response
- Added TODO marker and deferral spec to document current behavior and migration acceptance criteria

## Test plan
- [ ] `bundle exec rspec` passes (0 failures) — 395 examples
- [ ] `bundle exec rubocop` passes (0 offenses)
- [ ] Existing behavior preserved — no degradation

Related: LegionIO/legion-gaia#40